### PR TITLE
Fix first letter getting chopped off of a non-coloured MOTD

### DIFF
--- a/src/ServerBanner.php
+++ b/src/ServerBanner.php
@@ -71,9 +71,8 @@ class ServerBanner
                 if (isset($colors[$color_code])) {
                     $color_rgb = $colors[$color_code];
                     $last_color = $color_rgb;
+                    $text = substr($component, 1);
                 }
-
-                $text = substr($component, 1);
             }
 
             $color = imagecolorallocate($canvas, $last_color[0], $last_color[1], $last_color[2]);


### PR DESCRIPTION
Previously, a MOTD with no colour code as the first character would get the first letter removed:
```
Hello, world! -> ello, world!
```

This fixes that!

By the way, any idea how to support the "new" MOTD format? (Compared to the "old" one where it was a pure string of the MOTD with the old colour symbol

<img width="318" alt="Screen Shot 2022-02-15 at 13 25 25" src="https://user-images.githubusercontent.com/26070412/154151840-59162061-c2fa-469b-bdef-38de8489f844.png">

